### PR TITLE
单个验证错误时错误信息类型为字符串,ide错误报异常

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -154,7 +154,7 @@ class Validate
 
     /**
      * 验证失败错误信息
-     * @var array
+     * @var array|string
      */
     protected $error = [];
 


### PR DESCRIPTION
解决将获取到的错误传入限制参数类型为字符串的函数时ide报异常