### PR TITLE
PHP8.0  filter_var(): Argument top-think#3 ($options) must be of type array|int, null given

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -998,7 +998,7 @@ class Validate
             $param = isset($rule[1]) ? $rule[1] : null;
             $rule  = $rule[0];
         } else {
-            $param = null;
+            $param = 0;
         }
 
         return false !== filter_var($value, is_int($rule) ? $rule : filter_id($rule), $param);


### PR DESCRIPTION
PHP8.0  filter_var(): Argument #3 ($options) must be of type array|int, null given