### PR TITLE
修正 门面类注释格式

### DIFF
--- a/src/facade/Validate.php
+++ b/src/facade/Validate.php
@@ -16,49 +16,49 @@ use think\Facade;
 /**
  * @see \think\Validate
  * @mixin \think\Validate
- * @method \think\Validate rule(mixed $name, mixed $rule = '') static 添加字段验证规则
- * @method void extend(string $type, callable $callback = null, string $message='') static 注册扩展验证（类型）规则
- * @method void setTypeMsg(mixed $type, string $msg = null) static 设置验证规则的默认提示信息
- * @method \think\Validate message(mixed $name, string $message = '') static 设置提示信息
- * @method \think\Validate scene(string $name) static 设置验证场景
- * @method bool hasScene(string $name) static 判断是否存在某个验证场景
- * @method \think\Validate batch(bool $batch = true) static 设置批量验证
- * @method \think\Validate only(array $fields) static 指定需要验证的字段列表
- * @method \think\Validate remove(mixed $field, mixed $rule = true) static 移除某个字段的验证规则
- * @method \think\Validate append(mixed $field, mixed $rule = null) static 追加某个字段的验证规则
- * @method bool confirm(mixed $value, mixed $rule, array $data = [], string $field = '') static 验证是否和某个字段的值一致
- * @method bool different(mixed $value, mixed $rule, array $data = []) static 验证是否和某个字段的值是否不同
- * @method bool egt(mixed $value, mixed $rule, array $data = []) static 验证是否大于等于某个值
- * @method bool gt(mixed $value, mixed $rule, array $data = []) static 验证是否大于某个值
- * @method bool elt(mixed $value, mixed $rule, array $data = []) static 验证是否小于等于某个值
- * @method bool lt(mixed $value, mixed $rule, array $data = []) static 验证是否小于某个值
- * @method bool eq(mixed $value, mixed $rule) static 验证是否等于某个值
- * @method bool must(mixed $value, mixed $rule) static 必须验证
- * @method bool is(mixed $value, mixed $rule, array $data = []) static 验证字段值是否为有效格式
- * @method bool ip(mixed $value, mixed $rule) static 验证是否有效IP
- * @method bool requireIf(mixed $value, mixed $rule) static 验证某个字段等于某个值的时候必须
- * @method bool requireCallback(mixed $value, mixed $rule,array $data) static 通过回调方法验证某个字段是否必须
- * @method bool requireWith(mixed $value, mixed $rule, array $data) static 验证某个字段有值的情况下必须
- * @method bool filter(mixed $value, mixed $rule) static 使用filter_var方式验证
- * @method bool in(mixed $value, mixed $rule) static 验证是否在范围内
- * @method bool notIn(mixed $value, mixed $rule) static 验证是否不在范围内
- * @method bool between(mixed $value, mixed $rule) static between验证数据
- * @method bool notBetween(mixed $value, mixed $rule) static 使用notbetween验证数据
- * @method bool length(mixed $value, mixed $rule) static 验证数据长度
- * @method bool max(mixed $value, mixed $rule) static 验证数据最大长度
- * @method bool min(mixed $value, mixed $rule) static 验证数据最小长度
- * @method bool after(mixed $value, mixed $rule) static 验证日期
- * @method bool before(mixed $value, mixed $rule) static 验证日期
- * @method bool expire(mixed $value, mixed $rule) static 验证有效期
- * @method bool allowIp(mixed $value, mixed $rule) static 验证IP许可
- * @method bool denyIp(mixed $value, mixed $rule) static 验证IP禁用
- * @method bool regex(mixed $value, mixed $rule) static 使用正则验证数据
- * @method bool token(mixed $value, mixed $rule) static 验证表单令牌
- * @method bool dateFormat(mixed $value, mixed $rule) static 验证时间和日期是否符合指定格式
- * @method bool unique(mixed $value, mixed $rule, array $data = [], string $field = '') static 验证是否唯一
- * @method bool check(array $data, mixed $rules = []) static 数据自动验证
- * @method bool checkRule(mixed $data, mixed $rules = []) static 数据手动验证
- * @method mixed getError() static 获取错误信息
+ * @method static \think\Validate rule(mixed $name, mixed $rule = '') 添加字段验证规则
+ * @method static void extend(string $type, callable $callback = null, string $message='') 注册扩展验证（类型）规则
+ * @method static void setTypeMsg(mixed $type, string $msg = null) 设置验证规则的默认提示信息
+ * @method static \think\Validate message(mixed $name, string $message = '') 设置提示信息
+ * @method static \think\Validate scene(string $name) 设置验证场景
+ * @method static bool hasScene(string $name) 判断是否存在某个验证场景
+ * @method static \think\Validate batch(bool $batch = true) 设置批量验证
+ * @method static \think\Validate only(array $fields) 指定需要验证的字段列表
+ * @method static \think\Validate remove(mixed $field, mixed $rule = true) 移除某个字段的验证规则
+ * @method static \think\Validate append(mixed $field, mixed $rule = null) 追加某个字段的验证规则
+ * @method static bool confirm(mixed $value, mixed $rule, array $data = [], string $field = '') 验证是否和某个字段的值一致
+ * @method static bool different(mixed $value, mixed $rule, array $data = []) 验证是否和某个字段的值是否不同
+ * @method static bool egt(mixed $value, mixed $rule, array $data = []) 验证是否大于等于某个值
+ * @method static bool gt(mixed $value, mixed $rule, array $data = []) 验证是否大于某个值
+ * @method static bool elt(mixed $value, mixed $rule, array $data = []) 验证是否小于等于某个值
+ * @method static bool lt(mixed $value, mixed $rule, array $data = []) 验证是否小于某个值
+ * @method static bool eq(mixed $value, mixed $rule) 验证是否等于某个值
+ * @method static bool must(mixed $value, mixed $rule) 必须验证
+ * @method static bool is(mixed $value, mixed $rule, array $data = []) 验证字段值是否为有效格式
+ * @method static bool ip(mixed $value, mixed $rule) 验证是否有效IP
+ * @method static bool requireIf(mixed $value, mixed $rule) 验证某个字段等于某个值的时候必须
+ * @method static bool requireCallback(mixed $value, mixed $rule,array $data) 通过回调方法验证某个字段是否必须
+ * @method static bool requireWith(mixed $value, mixed $rule, array $data) 验证某个字段有值的情况下必须
+ * @method static bool filter(mixed $value, mixed $rule) 使用 filter_var 方式验证
+ * @method static bool in(mixed $value, mixed $rule) 验证是否在范围内
+ * @method static bool notIn(mixed $value, mixed $rule) 验证是否不在范围内
+ * @method static bool between(mixed $value, mixed $rule) between 验证数据
+ * @method static bool notBetween(mixed $value, mixed $rule) 使用 notbetween 验证数据
+ * @method static bool length(mixed $value, mixed $rule) 验证数据长度
+ * @method static bool max(mixed $value, mixed $rule) 验证数据最大长度
+ * @method static bool min(mixed $value, mixed $rule) 验证数据最小长度
+ * @method static bool after(mixed $value, mixed $rule) 验证日期
+ * @method static bool before(mixed $value, mixed $rule) 验证日期
+ * @method static bool expire(mixed $value, mixed $rule) 验证有效期
+ * @method static bool allowIp(mixed $value, mixed $rule) 验证IP许可
+ * @method static bool denyIp(mixed $value, mixed $rule) 验证IP禁用
+ * @method static bool regex(mixed $value, mixed $rule) 使用正则验证数据
+ * @method static bool token(mixed $value, mixed $rule) 验证表单令牌
+ * @method static bool dateFormat(mixed $value, mixed $rule) 验证时间和日期是否符合指定格式
+ * @method static bool unique(mixed $value, mixed $rule, array $data = [], string $field = '') 验证是否唯一
+ * @method static bool check(array $data, mixed $rules = []) 数据自动验证
+ * @method static bool checkRule(mixed $data, mixed $rules = []) 数据手动验证
+ * @method static mixed getError() 获取错误信息
  */
 class Validate extends Facade
 {

--- a/src/facade/Validate.php
+++ b/src/facade/Validate.php
@@ -50,8 +50,8 @@ use think\Facade;
  * @method static bool after(mixed $value, mixed $rule) 验证日期
  * @method static bool before(mixed $value, mixed $rule) 验证日期
  * @method static bool expire(mixed $value, mixed $rule) 验证有效期
- * @method static bool allowIp(mixed $value, mixed $rule) 验证IP许可
- * @method static bool denyIp(mixed $value, mixed $rule) 验证IP禁用
+ * @method static bool allowIp(mixed $value, mixed $rule) 验证 IP 许可
+ * @method static bool denyIp(mixed $value, mixed $rule) 验证 IP 禁用
  * @method static bool regex(mixed $value, mixed $rule) 使用正则验证数据
  * @method static bool token(mixed $value, mixed $rule) 验证表单令牌
  * @method static bool dateFormat(mixed $value, mixed $rule) 验证时间和日期是否符合指定格式


### PR DESCRIPTION
原有注释无法通过 [PHPStan](https://phpstan.org/) 静态分析。
![image](https://github.com/user-attachments/assets/ed062a0e-7551-4dc2-9e4f-c7c47b184b2e)

此 PR 修正了注释格式，并按 [中文技术文档的写作规范](https://github.com/ruanyf/document-style-guide/blob/master/docs/text.md#%E5%AD%97%E9%97%B4%E8%B7%9D) 调整字间距。