### PR TITLE
修正多因子验证错误提示

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -751,7 +751,7 @@ class Validate
                     if ($this->batch) {
                         // 批量验证
                     } elseif ($this->failException) {
-                        throw new ValidateException($result, $name);
+                         throw new ValidateException(str_replace(substr($result, 0, strspn($result, $name)),$name,$result), $name);
                     } else {
                         return false;
                     }


### PR DESCRIPTION
$result为错误提示,$name为层级key信息.
将$result中与$name相同的前缀信息完整的替换为$name使其符合错误验证提示.